### PR TITLE
Updated setuptools version to resolve vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pip~=21.3.1
-setuptools~=59.5.0
+setuptools~=65.5.1
 tabulate~=0.8.9
 types-tabulate~=0.8.9


### PR DESCRIPTION
Updated setuptool library version to resolve vulnerability. Previous version of library allowed remote attackers to cause a denial of service by fetching malicious HTML from a PyPI package or custom PackageIndex page due to a vulnerable Regular Expression in `package_index`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
