### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-workflow.yml
+++ b/.github/workflows/python-workflow.yml
@@ -1,4 +1,6 @@
 name: python-checks
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/driftctl-cross-account-cross-region/security/code-scanning/8](https://github.com/aws-samples/driftctl-cross-account-cross-region/security/code-scanning/8)

The best way to fix the problem is to explicitly specify a `permissions:` block to limit the default token to the minimal permissions needed. In this case, setting `permissions: contents: read` at the top level of the workflow (just after the workflow's `name:` and before `on:`) is sufficient, because none of the jobs perform actions that need greater access. If in the future any job requires elevated permissions, a specific `permissions:` block can be added at the job level.

**Steps:**
- Add the following block after `name: python-checks`:  
  ```yaml
  permissions:
    contents: read
  ```
- No imports, new methods, or additional definitions are needed, as only the workflow YAML is being updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
