### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/terraform-workflow.yml
+++ b/.github/workflows/terraform-workflow.yml
@@ -1,4 +1,6 @@
 name: terraform-checks
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/driftctl-cross-account-cross-region/security/code-scanning/6](https://github.com/aws-samples/driftctl-cross-account-cross-region/security/code-scanning/6)

The optimal fix is to add a `permissions` block to limit the permissions of the GITHUB_TOKEN. Since the workflow only checks out code and runs security checks (it does not write to the repository, create/modify PRs, etc.), we should set `contents: read` permission, which will be the minimal permission required by actions/checkout and no more. This can be done either at the root level (applies to all jobs unless overridden), or within the job itself if you expect to extend the workflow later with jobs requiring different permissions – for now, root level is simplest. The specific change is a single block:

Add, after the `name: terraform-checks` line (line 1), a `permissions:` block:
```yaml
permissions:
  contents: read
```

No new imports, methods, or definitions are needed; just the addition in the .github/workflows/terraform-workflow.yml file as described.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
